### PR TITLE
fix: update outdated frontend docs link in resources.component.tsx

### DIFF
--- a/src/resources/resources.component.tsx
+++ b/src/resources/resources.component.tsx
@@ -20,7 +20,7 @@ function Resources() {
         <Card
           title={t('frontendDocs', 'Frontend docs')}
           subtitle={t('learnExplainer', 'Learn how to use the O3 framework') + '.'}
-          link="https://o3-docs.vercel.app"
+          link="https://openmrs.atlassian.net/wiki/spaces/docs/pages/151093495/Introduction+to+O3+for+Developers"
         />
         <Card
           title={t('designDocs', 'Design docs')}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates a deprecated documentation link in `resources.component.tsx` that previously pointed to the outdated docs.

**Old link:**
https://o3-docs.openmrs.org/

**New link:**
https://openmrs.atlassian.net/wiki/spaces/docs/pages/151093495/Introduction+to+O3+for+Developers

This change ensures new developers using the esm-template-app are directed to the actively maintained documentation.

## Screenshots
*None*

## Related Issue
*None currently – was not able to create a jira ticket, since component section does not have "esm-template-app"*

## Other
*None*
